### PR TITLE
Harmless UninitializedPropertyAccessException

### DIFF
--- a/app/src/main/java/com/pavelrekun/rekado/screens/payload_fragment/PayloadsView.kt
+++ b/app/src/main/java/com/pavelrekun/rekado/screens/payload_fragment/PayloadsView.kt
@@ -49,7 +49,9 @@ class PayloadsView(private val activity: BaseActivity, private val fragment: Fra
     }
 
     override fun updateList() {
-        adapter.updateList(PayloadHelper.getPayloads())
+        if(this::adapter.isInitialized){
+            adapter.updateList(PayloadHelper.getPayloads())
+        }
     }
 
     override fun initClickListeners() {


### PR DESCRIPTION
When Read Storage permission is granted and the first asset copied the adapter is refreshed when it finishes but the adapter is still no initialized, therefore throwing a kotlin.UninitializedPropertyAccessException, so I have added a simple check if it is initialized.